### PR TITLE
[VAULT-50]: Change datatype to float when writing

### DIFF
--- a/fcsparser/_version.py
+++ b/fcsparser/_version.py
@@ -1,1 +1,1 @@
-version = "0.1.7.notable"
+version = "0.2.1.notable"

--- a/fcsparser/api.py
+++ b/fcsparser/api.py
@@ -556,6 +556,14 @@ class FCSParser(object):
             # __header__ shouldn't be a part of the TEXT
             if k == "__header__":
                 continue
+
+            # Since we are only capable of writing the data as float, this must
+            # be changed to "F" regardless of the original value
+            # Not changing the actual value in annotation since that
+            # would break the compatibility check in _data_to_byte_string()
+            if k == "$DATATYPE":
+                v = "F"
+
             formatted_annotation.append(
                 BYTE_SEP.join([str(k).encode("utf-8"), str(v).encode("utf-8")])
             )
@@ -571,6 +579,8 @@ class FCSParser(object):
             )
 
         endian = self._get_endian(self.annotation["$BYTEORD"])
+        # Since we are only writing IEEE-754 single precision floating point numbers, we must
+        # ALWAYS change the "$DATATYPE" to "F"
         return BYTE_SEP + self._data.astype("{}f".format(endian)).tobytes()
 
     def write_to_file(self, path):


### PR DESCRIPTION
This PR changes the `$DATATYPE` keyword in the FCS header to `F` (Float) when writing since the data encoding only supports floats.